### PR TITLE
STEAPP-439: fixed bug, printer didn't restart after emergancy_stop. Optimized code the gcode.py.

### DIFF
--- a/klippy/gcode.py
+++ b/klippy/gcode.py
@@ -174,6 +174,8 @@ class GCodeDispatch:
     args_r = re.compile('([A-Z_]+|[A-Z*/])')
     def _process_commands(self, commands, need_ack=True):
         for line in commands:
+            if line == '':
+                continue
             # Ignore comments and leading/trailing spaces
             line = origline = line.strip()
             cpos = line.find(';')

--- a/stereotech_config/power_control.cfg
+++ b/stereotech_config/power_control.cfg
@@ -42,15 +42,3 @@ gcode:
 gcode:
     SET_GCODE_VARIABLE MACRO=END VARIABLE=power_off VALUE={params.VALUE|default(0)}
 
-
-[gcode_macro RESTART]
-rename_existing: RESTART_OLD
-gcode:
-    SAVE_STATE_MODULE
-    RESTART_OLD
-
-[gcode_macro FIRMWARE_RESTART]
-rename_existing: FIRMWARE_RESTART_OLD
-gcode:
-    SAVE_STATE_MODULE
-    FIRMWARE_RESTART_OLD


### PR DESCRIPTION
Optimized the code, in gcode.py, made a condition to check for an empty string when bypassing the commands variable in the loop. 
`commands = ['', '', '', '', 'SET_GCODE_OFFSET Z=1.25000000909 A=-3.89659678967', '', '', '', '', 'G10 L2 P2 X159.882812502 Y247.564296875 Z38.111953144', '', '', '', '', ...]`