### PR TITLE
STEAPP-809: Z-axis movements before printing have been removed. Because the printhead crashes into the model after the print is restored due to a power outage

### DIFF
--- a/stereotech_config/750/print_macros.cfg
+++ b/stereotech_config/750/print_macros.cfg
@@ -204,7 +204,7 @@ gcode:
     M107
     G28
     {% if printer.heater_bed.temperature > 5 %}
-        G0 Y20 Z30 F2100
+        G0 Y20 F3600
     {% else %}
         G0 X100 Y20 C1 F3600
     {% endif %}

--- a/stereotech_config/common/print_macros.cfg
+++ b/stereotech_config/common/print_macros.cfg
@@ -210,7 +210,7 @@ gcode:
         G28
     {% endif %}
     {% if printer["gcode_button five_axis_module"].state == "RELEASED" %}
-        G0 Y20 Z30 F2100
+        G0 Y20 F3600
     {% else %}
         G0 Y20 C1 F3600
     {% endif %}


### PR DESCRIPTION
…